### PR TITLE
Add Ice Type Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ You can check out a live version of this project hosted on GitHub Pages [here](h
 - You can select specific rows or cells, that have pre-determined attributes.
   - The "Glaceon" and "Talonflame" rows have this data attribute.
   - The cells "Weavile" and "Arcanine" have this data attribute.
+- You can select only the ice type Pokemon while not selecting the header row.

--- a/app.js
+++ b/app.js
@@ -1,3 +1,7 @@
+// Grab Specific Tables
+const iceTable = document.querySelector('.ice-table');
+const fireTable = document.querySelector('.fire-table');
+
 // Grab all the buttons
 const selectOddBtn = document.getElementById("selectOdd");
 const selectDataAttrBtn = document.getElementById("selectDataAttr");
@@ -50,9 +54,17 @@ function selectDataAttr() {
     }
 }
 
+// Function to select only the ice type pokemon.
 function selectOnlyIce() {
     stripUnusedClasses();
-    selectOnlyIceBtn.classList.add("active");
+    selectOnlyIceTypesBtn.classList.add("active");
+
+    selectionDesc.innerHTML = 'Querying only on the Ice Table, and using <code>querySelectorAll("tr: not(th)")</code> plus a for loop, I am able to highlight only the ice type Pokemon, while excluding the header row.'
+
+    const iceTypes = iceTable.querySelectorAll("tr :not(th)");
+    for (let iceType = 0; iceType < iceTypes.length; iceType++){
+        iceTypes[iceType].classList.add("highlight");
+    }
 }
 
 // Helper Functions


### PR DESCRIPTION
Button will only select the ice type pokemon, from the first list of ice types. It will exclude the highlighting from the header row.